### PR TITLE
Add git lfs to lambda layer

### DIFF
--- a/lambda2/build.sh
+++ b/lambda2/build.sh
@@ -7,7 +7,7 @@ rm layer.zip
 docker run --rm -v "$PWD":/tmp/layer lambci/yumda:2 bash -c "
   curl -sSf 'https://packagecloud.io/install/repositories/github/git-lfs/config_file.repo?os=amzn&dist=2&source=script' > /lambda/etc/yum.repos.d/github_git-lfs.repo && \
   yum -q makecache -y --disablerepo='*' --enablerepo='github_git-lfs' --enablerepo='github_git-lfs-source' && \
-  yum install -y git-${GIT_VERSION} git-lfs && \
+  yum install -y git-${GIT_VERSION} git-lfs-${GIT_LFS_VERSION} && \
   mv /lambda/usr/bin/git-lfs /lambda/opt/bin/git-lfs && \
   cd /lambda/opt && \
   zip -yr /tmp/layer/layer.zip .

--- a/lambda2/build.sh
+++ b/lambda2/build.sh
@@ -5,7 +5,10 @@
 rm layer.zip
 
 docker run --rm -v "$PWD":/tmp/layer lambci/yumda:2 bash -c "
-  yum install -y git-${GIT_VERSION} && \
+  curl -sSf 'https://packagecloud.io/install/repositories/github/git-lfs/config_file.repo?os=amzn&dist=2&source=script' > /lambda/etc/yum.repos.d/github_git-lfs.repo && \
+  yum -q makecache -y --disablerepo='*' --enablerepo='github_git-lfs' --enablerepo='github_git-lfs-source' && \
+  yum install -y git-${GIT_VERSION} git-lfs && \
+  mv /lambda/usr/bin/git-lfs /lambda/opt/bin/git-lfs && \
   cd /lambda/opt && \
   zip -yr /tmp/layer/layer.zip .
 "

--- a/lambda2/config.sh
+++ b/lambda2/config.sh
@@ -1,2 +1,3 @@
 export LAYER_NAME=git-lambda2
 export GIT_VERSION=2.29.0
+export GIT_LFS_VERSION=2.12.1

--- a/lambda2/test/index.js
+++ b/lambda2/test/index.js
@@ -12,4 +12,6 @@ exports.handler = async(event) => {
   execSync('ldd /opt/bin/ssh', { encoding: 'utf8', stdio: 'inherit' })
 
   execSync('ssh -V', { encoding: 'utf8', stdio: 'inherit' })
+
+  execSync('git lfs', { encoding: 'utf8', stdio: 'inherit' })
 }


### PR DESCRIPTION
Resolves lambci/git-lambda-layer#22

This adds the appropriate `git-lfs` RPM repo and validates its signature, then installs it with the `yum install` command. We have to manually move the `git-lfs` binary (which is [the only file required for git-lfs](https://github.com/git-lfs/git-lfs/wiki/Installation#other)) into the `/opt/bin/` folder of the output so that it will be available in the `$PATH` in the lambda layer.

This manual handling of the RPM repo is done because the [standard git-lfs install script](https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh) has hardcoded `/etc/` all over the place, whereas we need it to respect the `/lambda/` root.
