### PR TITLE
fix build for libcrypto.so.10

### DIFF
--- a/lambda2/build.sh
+++ b/lambda2/build.sh
@@ -5,7 +5,11 @@
 rm layer.zip
 
 docker run --rm -v "$PWD":/tmp/layer lambci/yumda:2 bash -c "
-  yum install -y git-${GIT_VERSION} && \
+  yum install -y git-${GIT_VERSION} openssl-libs openssl-devel && \
   cd /lambda/opt && \
+  # Copy required OpenSSL libraries
+  mkdir -p lib && \
+  cp -a /usr/lib64/libcrypto.so* lib/ && \
+  cp -a /usr/lib64/libssl.so* lib/ && \
   zip -yr /tmp/layer/layer.zip .
 "


### PR DESCRIPTION
Fixed build.sh to include `libcrypto` and `libssl` files that are currently missing in the layer to allow ssh clone

How did I verify it work?
Ran build.sh locally
uploaded manually the git layer to aws
Ran clone repo command with ssh repo - `git@github.com:mhart/aws4.git`